### PR TITLE
performance improvements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,3 @@ import {Notable} from "./notable";
 
 const notable = new Notable();
 notable.init();
-
-// Ughhh! Have to do this because the script
-// is not reloaded on the change of page
-window.setInterval(notable.refresh, 300);

--- a/src/notable.js
+++ b/src/notable.js
@@ -358,10 +358,8 @@ export class Notable {
 
       // Count the number of reactions against this comment
       commentReaction.forEach(commentReaction => {
-        let reactionText = commentReaction.innerText;
-        reactionText = reactionText.replace(/\D+/, '');
-
-        groupReactionCount += parseInt(reactionText, 10);
+        let reactionCountTextNode = commentReaction.childNodes[2].textContent;
+        groupReactionCount += parseInt(reactionCountTextNode, 10);
       });
 
       if (!groupReactionCount) {

--- a/src/notable.js
+++ b/src/notable.js
@@ -42,6 +42,13 @@ export class Notable {
       this.refresh();
     });
 
+    window.addEventListener('DOMNodeInserted', (e) => {
+      const insertedElement = this.getInsertedDomElement(e.target);
+      if(insertedElement) {
+        this.refresh();
+      }
+    });
+
     window.addEventListener('click', (e) => {
       const reactionButton = this.getReactionToSelect(e.target);
       if (reactionButton) {
@@ -95,6 +102,11 @@ export class Notable {
     }
 
     return findAncestor(clickedElement, CLASS_REACTION);
+  }
+
+  getInsertedDomElement( mutatedElement) {
+    //Todo: determine which kind of changes is targeted
+    return mutatedElement;
   }
 
   /**


### PR DESCRIPTION
- [x] avoid using regex to get reaction count
- [x] avoid using 300ms interval to refresh the extension, instead, it is refreshed not upon `DOMNodeInserted` event