### PR TITLE
ghnc on top of gh user images

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -8,6 +8,7 @@
   border: 1px solid #d1d5da;
   border-radius: 3px;
   width: 65px;
+  z-index: 100;
 }
 
 .ghnc-container .btn {


### PR DESCRIPTION
github introduced z-index:1 for user images which made it on top of ghnc.